### PR TITLE
fix _overflow has not been initialized

### DIFF
--- a/lib/src/magic_mask.dart
+++ b/lib/src/magic_mask.dart
@@ -15,7 +15,7 @@ class MagicMask {
   static const String _multipleOpt = 'multiple';
 
   late bool _reverse;
-  late bool _overflow;
+  bool _overflow = false;
   late int _charIndex;
   late int _tagIndex;
   late int _step;


### PR DESCRIPTION
As mentioned on [#13](https://github.com/danilocoppi/flutter-textfield-mask/issues/13) I fixed the late bool problem.